### PR TITLE
Fix: Resolve null nfInstances return during AMF->UDM discovery

### DIFF
--- a/producer/nf_discovery.go
+++ b/producer/nf_discovery.go
@@ -238,45 +238,41 @@ func buildFilter(queryParameters url.Values) bson.M {
 	// Mcc: Pattern: '^[0-9]{3}$'
 	// Mnc: Pattern: '^[0-9]{2,3}$'
 	if queryParameters["target-plmn-list"] != nil {
-		targetPlmnList := queryParameters["target-plmn-list"][0]
-		targetPlmnListSplit := strings.Split(targetPlmnList, ",")
-		var targetPlmnListBsonArray bson.A
+		targetPlmnListStr := queryParameters["target-plmn-list"][0]
 
-		var temptargetPlmn string
-		for i, v := range targetPlmnListSplit {
-			if i%2 == 0 {
-				temptargetPlmn = v
-			} else {
-				temptargetPlmn += ","
-				temptargetPlmn += v
+		// The query parameter returns a JSON Array string (e.g., '[{"mcc":"208","mnc":"93"}]').
+		// Changed to Slice []models.PlmnId to handle the JSON Array input correctly
+		var targetPlmns []models.PlmnId
 
-				targetPlmnListtruct := &models.PlmnId{}
-				err := json.Unmarshal([]byte(temptargetPlmn), targetPlmnListtruct)
-				if err != nil {
-					logger.DiscoveryLog.Warnln("Unmarshal Error in targetPlmnListtruct: ", err)
+		// Use standard Unmarshal to parse the full array, replacing manual string splitting
+		err := json.Unmarshal([]byte(targetPlmnListStr), &targetPlmns)
+
+		if err != nil {
+			logger.DiscoveryLog.Warnln("Unmarshal Error in targetPlmnList: ", err)
+		} else {
+			var targetPlmnListBsonArray bson.A
+
+			// Iterate directly over the parsed structs
+			for _, plmn := range targetPlmns {
+				plmnBson := bson.M{
+					"mcc": plmn.Mcc,
+					"mnc": plmn.Mnc,
 				}
 
-				targetPlmnByteArray, err := bson.Marshal(targetPlmnListtruct)
-				if err != nil {
-					logger.DiscoveryLog.Warnln("Unmarshal Error in targetPlmnListtruct: ", err)
-				}
+				// Append to the list of criteria. This checks if the NF's 'plmnList' contains this specific PLMN.
+				targetPlmnListBsonArray = append(targetPlmnListBsonArray, bson.M{
+					"plmnList": bson.M{"$elemMatch": plmnBson},
+				})
+			}
 
-				targetPlmnBsonM := bson.M{}
-				err = bson.Unmarshal(targetPlmnByteArray, &targetPlmnBsonM)
-				if err != nil {
-					logger.DiscoveryLog.Errorln("unmarshal error in targetPlmnBsonM:", err)
+			// Only apply the filter if valid PLMNs were parsed
+			if len(targetPlmnListBsonArray) > 0 {
+				targetPlmnListFilter := bson.M{
+					"$or": targetPlmnListBsonArray,
 				}
-				logger.DiscoveryLog.Debugln("temp target Plmn:", temptargetPlmn)
-
-				targetPlmnListBsonArray = append(targetPlmnListBsonArray, bson.M{"plmnList": bson.M{"$elemMatch": targetPlmnBsonM}})
+				filter["$and"] = append(filter["$and"].([]bson.M), targetPlmnListFilter)
 			}
 		}
-
-		targetPlmnListFilter := bson.M{
-			"$or": targetPlmnListBsonArray,
-		}
-
-		filter["$and"] = append(filter["$and"].([]bson.M), targetPlmnListFilter)
 	}
 
 	// [Query-6] requester-plmn-list


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
This PR fixes a critical bug in the NRF Discovery procedure (nf_discovery.go) where the target-plmn-list query parameter was being parsed incorrectly.

The target-plmn-list parameter is received as a JSON Array string (e.g., [{"mcc":"208","mnc":"93"}]). The previous code attempted to unmarshal this input into a single models.PlmnId struct. This caused a json: cannot unmarshal array error, which the system logged as a warning but continued execution. As a result, the database filter for PLMN was malformed/empty, causing MongoDB to return 0 results.

Without this fix, any NF Discovery request (e.g., AMF -> UDM) that filters by PLMN fails to find instances, leading to timeouts in core network procedures.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#17](https://github.com/5GC-DEV/nrf-cdac/issues/17)

**Test Report Added?**:
> /kind TESTED


**Test Report**:
NA

**Special notes for your reviewer**:
NIL